### PR TITLE
Adding scripts to run node on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store

--- a/merge-devnet-1/README.md
+++ b/merge-devnet-1/README.md
@@ -36,3 +36,17 @@ pre_genesis_fork_digest: 0x86db5f86
 
 
 ```
+
+
+## On macOS
+
+after installing all the dependencies you can run the following commands to run
+your node:    
+     
+**Connect with Geth-LH**      
+ 1. Make script executable: `chmod +x ./scripts/runGethLh.sh`     
+ 2. Run the script: `./scripts/runGethLh.sh`    
+
+**Connect with Geth-Teku**      
+ 1. Make script executable: `chmod +x ./scripts/runGethTeku.sh`     
+ 2. Run the script: `./scripts/runGethTeku.sh`    

--- a/merge-devnet-1/scripts/runGethLH.sh
+++ b/merge-devnet-1/scripts/runGethLH.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 dir="$PWD"
-command1=''
 
 osascript -e 'tell application "Terminal" to do script "cd '$dir'; cd .. ; \
    ./go-ethereum/build/bin/geth init genesis.json  --datadir \"datadir-lh\"; \

--- a/merge-devnet-1/scripts/runGethLH.sh
+++ b/merge-devnet-1/scripts/runGethLH.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+dir="$PWD"
+command1=''
+
+osascript -e 'tell application "Terminal" to do script "cd '$dir'; cd .. ; \
+   ./go-ethereum/build/bin/geth init genesis.json  --datadir \"datadir-lh\"; \
+   ./go-ethereum/build/bin/geth --datadir \"datadir-lh\" --http --http.api=\"engine,eth,web3,net,debug\" --http.corsdomain \"*\" --networkid=1337402 --syncmode=full  --catalyst console"'
+
+
+osascript -e 'tell application "Terminal" to do script "cd '$dir'; cd .. ;\
+  lighthouse \\
+  --spec mainnet \\
+  --testnet-dir ./ \\
+  --debug-level info \\
+  beacon_node \\
+  --datadir ./testnet-lh1 \\
+  --dummy-eth1 \\
+  --http \\
+  --http-allow-sync-stalled \\
+  --metrics \\
+  --merge \\
+  --execution-endpoints http://127.0.0.1:8545 \\
+  --enr-udp-port=9001 \\
+  --enr-tcp-port=9001 \\
+  --discovery-port=9001 \\
+  --boot-nodes=\"enr:-Ly4QCjDLaUNpn-PQpUFAfaj2oVI21yiOyKYQXBNlqLi1jEcb_keXbMAoUF2XGK1gLUG_UmDxDrq3exsjfWtNvc8eYsBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC54JZVMQAAcAQAAAAAAAAAgmlkgnY0gmlwhIm4YwOJc2VjcDI1NmsxoQLqesNkBD2BHJtbCBhpzEsQqCWyVFKmfG4P6xkxqxsvKIhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA\""'
+
+

--- a/merge-devnet-1/scripts/runGethTeku.sh
+++ b/merge-devnet-1/scripts/runGethTeku.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+dir="$PWD"
+command1=''
+
+osascript -e 'tell application "Terminal" to do script "cd '$dir'; cd .. ; \
+   ./go-ethereum/build/bin/geth init genesis.json  --datadir \"datadir-teku\"; \
+   ./go-ethereum/build/bin/geth --datadir \"datadir-teku\" --http --http.api=\"engine,eth,web3,net,debug\" --http.corsdomain \"*\" --networkid=1337402 --syncmode=full  --catalyst console"'
+
+
+osascript -e 'tell application "Terminal" to do script "cd '$dir'; cd .. ;\
+  ./teku/build/install/teku/bin/teku \\
+  --data-path \"datadir-teku\" \\
+  --network https://github.com/eth2-clients/merge-testnets/raw/main/merge-devnet-1/config.yaml \\
+  --initial-state https://github.com/eth2-clients/merge-testnets/raw/main/merge-devnet-1/genesis.ssz \\
+  --Xee-endpoint http://localhost:8545 \\
+  --p2p-discovery-bootnodes \"enr:-Iq4QKuNB_wHmWon7hv5HntHiSsyE1a6cUTK1aT7xDSU_hNTLW3R4mowUboCsqYoh1kN9v3ZoSu_WuvW9Aw0tQ0Dxv6GAXxQ7Nv5gmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk\" \\
+  --log-destination console"'
+
+

--- a/merge-devnet-1/scripts/runGethTeku.sh
+++ b/merge-devnet-1/scripts/runGethTeku.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 dir="$PWD"
-command1=''
 
 osascript -e 'tell application "Terminal" to do script "cd '$dir'; cd .. ; \
    ./go-ethereum/build/bin/geth init genesis.json  --datadir \"datadir-teku\"; \


### PR DESCRIPTION
A simple script to automatically start the node on macOS, saves you the time of opening two terminal windows and running the commands. Can only be executed if all de dependencies listed on [this](https://hackmd.io/dFzKxB3ISWO8juUqPpJFfw?view) guide were followed.