### PR TITLE
Adds CONFIG_NAME to config.yaml

### DIFF
--- a/kiln/config.yaml
+++ b/kiln/config.yaml
@@ -1,5 +1,6 @@
 # Extends the mainnet preset
 PRESET_BASE: 'mainnet'
+CONFIG_NAME: 'kiln'
 # Genesis
 # ---------------------------------------------------------------
 MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 95000


### PR DESCRIPTION
This field has been added to the configs in the spec:

https://github.com/ethereum/consensus-specs/blob/9f643d8dbf678430bc6707f0e5b914d0bf62545c/configs/mainnet.yaml#L11

Lighthouse is expecting it, unfortunately.