### PR TITLE
Enable proposer boost at 40% on Ropsten

### DIFF
--- a/ropsten-beacon-chain/config.yaml
+++ b/ropsten-beacon-chain/config.yaml
@@ -59,6 +59,11 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 65536
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 40%
+PROPOSER_SCORE_BOOST: 40
+
 # Deposit contract
 # ---------------------------------------------------------------
 DEPOSIT_CHAIN_ID: 3


### PR DESCRIPTION
Ropsten should be as close to mainnet (and Prater) as possible, and should therefore run with proposer boost enabled. The boost is set to 40% per the most recent update (see https://github.com/ethereum/consensus-specs/pull/2895 for rationale).